### PR TITLE
removed 'xf86-input-joystick'

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,6 @@ license=('GPL')
 groups=()
 depends=(
 	'xf86-input-evdev'
-	'xf86-input-joystick'
 	'xf86-input-keyboard'
 	'xf86-input-libinput'
 	'xf86-input-mouse'


### PR DESCRIPTION
this package is down in AUR
https://www.archlinux.org/packages/extra/i686/xf86-input-joystick/